### PR TITLE
Bump mio to 0.8.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [


### PR DESCRIPTION
bump the mio dependency to 0.8.11.

Solves the associated security alert.